### PR TITLE
do not load plugins if none exist

### DIFF
--- a/src/proxy/pluginLoader/PluginManager.ts
+++ b/src/proxy/pluginLoader/PluginManager.ts
@@ -59,13 +59,14 @@ export class PluginManager extends EventEmitter {
     }
     pluginsString = pluginsString.substring(0, pluginsString.length - 1);
     this._logger.info(`Found ${pluginMeta.size} plugin(s): ${pluginsString}`);
-
-    this._logger.info(`Loading ${pluginMeta.size} plugin(s)...`);
-    const successLoadCount = await this._loadPlugins(
-      pluginMeta,
-      this._getLoadOrder(pluginMeta)
-    );
-    this._logger.info(`Successfully loaded ${successLoadCount} plugin(s).`);
+    if(pluginMeta.size !== 0){
+      this._logger.info(`Loading ${pluginMeta.size} plugin(s)...`);
+      const successLoadCount = await this._loadPlugins(
+        pluginMeta,
+        this._getLoadOrder(pluginMeta)
+      );
+      this._logger.info(`Successfully loaded ${successLoadCount} plugin(s).`);
+    }
     this.emit("pluginsFinishLoading", this);
   }
 


### PR DESCRIPTION
when removing all plugins from the plugin folder, the logger outputs `Successfully loaded undefined plugin(s).`

```
I 2023-08-12T11:27:36.439Z Launcher: Loading plugins...
I 2023-08-12T11:27:36.451Z PluginManager: Loading plugin metadata files...
I 2023-08-12T11:27:36.479Z PluginManager: Found 0 plugin(s): 
I 2023-08-12T11:27:36.480Z PluginManager: Loading 0 plugin(s)...
I 2023-08-12T11:27:36.534Z PluginManager: Successfully loaded undefined plugin(s).
I 2023-08-12T11:27:36.536Z Launcher: Launching EaglerProxy...
I 2023-08-12T11:27:36.546Z EaglerProxy-0: Starting EaglerProxy v1.0.8...
I 2023-08-12T11:27:36.633Z SkinServer: Started EaglercraftX skin server.
I 2023-08-12T11:27:36.921Z EaglerProxy-0: Started WebSocket server and binded to 0.0.0.0 on port 8080.
W 2023-08-12T11:27:37.357Z EaglerProxy-0: Error polling no:46625 for MOTD: Error: getaddrinfo ENOTFOUND no
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:109:26)
```

this patch makes it so that if there are 0 plugins detected, it will skip loading plugins.